### PR TITLE
Fix spec kit initialization path typing

### DIFF
--- a/src/spec-kit/specKitManager.ts
+++ b/src/spec-kit/specKitManager.ts
@@ -94,12 +94,19 @@ export class SpecKitManager {
       );
     }
 
-    const [safeSpecsDir, safeTemplatesDir, safeScriptsDir, safeMemoryDir] = [
-      specsDir,
-      templatesDir,
-      scriptsDir,
-      memoryDir,
-    ];
+    const ensureSafePath = (value: string | null, name: string): string => {
+      if (!value) {
+        throw new Error(
+          `Failed to resolve safe path for ${name}. Check workspace permissions and path validity.`
+        );
+      }
+      return value;
+    };
+
+    const safeSpecsDir = ensureSafePath(specsDir, 'specsDir');
+    const safeTemplatesDir = ensureSafePath(templatesDir, 'templatesDir');
+    const safeScriptsDir = ensureSafePath(scriptsDir, 'scriptsDir');
+    const safeMemoryDir = ensureSafePath(memoryDir, 'memoryDir');
 
     // Create directory structure
     await this.createDirectoryStructure([


### PR DESCRIPTION
## Summary
- ensure Spec Kit directory initialization converts validated safe paths to strict strings
- add helper that throws if any safe path becomes null during initialization

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_b_68ce2fa91e44832ca4122ae42adcc115