### PR TITLE
Add spec telemetry syncing and machine-readable artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
         {
           "id": "astraforge.apiTester",
           "name": "API Tester"
+        },
+        {
+          "id": "astraforge.specTelemetry",
+          "name": "Spec Telemetry"
         }
       ]
     },

--- a/src/providers/specTelemetryDashboard.ts
+++ b/src/providers/specTelemetryDashboard.ts
@@ -1,0 +1,300 @@
+import * as vscode from 'vscode';
+import { SpecKitManager } from '../spec-kit/specKitManager';
+import { GitManager } from '../git/gitManager';
+import { WorkflowManager } from '../workflow/workflowManager';
+import { SpecSync } from '../workflow/specSync';
+import { logger } from '../utils/logger';
+
+export class SpecTelemetryDashboardProvider implements vscode.WebviewViewProvider {
+  private view?: vscode.WebviewView;
+  private readonly specSync: SpecSync;
+
+  constructor(
+    private readonly extensionUri: vscode.Uri,
+    private readonly specKitManager: SpecKitManager,
+    private readonly gitManager: GitManager,
+    private readonly workflowManager?: WorkflowManager
+  ) {
+    this.specSync = new SpecSync(this.gitManager, this.specKitManager);
+  }
+
+  async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
+    this.view = webviewView;
+    webviewView.webview.options = {
+      enableScripts: true,
+    };
+    webviewView.webview.html = this.getHtml(webviewView.webview);
+
+    webviewView.webview.onDidReceiveMessage(async message => {
+      if (message?.command === 'refresh') {
+        await this.pushData();
+      }
+    });
+
+    webviewView.onDidChangeVisibility(async () => {
+      if (webviewView.visible) {
+        await this.pushData();
+      }
+    });
+
+    await this.pushData();
+  }
+
+  private async pushData(): Promise<void> {
+    if (!this.view) {
+      return;
+    }
+
+    const activePhase = this.workflowManager?.getActivePhase() ?? 'Planning';
+
+    try {
+      const reports = await this.specSync.generateReports(activePhase);
+      reports.forEach(report => {
+        this.workflowManager?.ingestSpecDeviations(report);
+      });
+
+      this.view.webview.postMessage({
+        type: 'spec-sync-report',
+        payload: {
+          activePhase,
+          reports,
+        },
+      });
+    } catch (error: any) {
+      logger.error(`SpecTelemetryDashboard: failed to push data: ${error}`);
+      vscode.window.showErrorMessage(
+        `Spec Telemetry dashboard failed to refresh: ${error?.message || error}`
+      );
+    }
+  }
+
+  private getHtml(webview: vscode.Webview): string {
+    const nonce = Date.now().toString(36);
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spec Telemetry</title>
+    <style>
+      body {
+        font-family: var(--vscode-font-family);
+        color: var(--vscode-foreground);
+        background: var(--vscode-sideBar-background);
+        margin: 0;
+        padding: 0.75rem;
+      }
+      h2 {
+        font-size: 1.1rem;
+        margin: 0 0 0.25rem 0;
+      }
+      .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.75rem;
+      }
+      .phase-pill {
+        background: var(--vscode-badge-background);
+        color: var(--vscode-badge-foreground);
+        padding: 0.2rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+      }
+      button.refresh {
+        background: var(--vscode-button-background);
+        color: var(--vscode-button-foreground);
+        border: none;
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      button.refresh:hover {
+        background: var(--vscode-button-hoverBackground);
+      }
+      .report {
+        border: 1px solid var(--vscode-panel-border);
+        border-radius: 6px;
+        padding: 0.75rem;
+        margin-bottom: 0.75rem;
+        background: var(--vscode-editor-background);
+      }
+      .progress-bar {
+        width: 100%;
+        background: var(--vscode-editor-inactiveSelectionBackground);
+        border-radius: 4px;
+        overflow: hidden;
+        margin: 0.25rem 0 0.5rem 0;
+      }
+      .progress-bar span {
+        display: block;
+        height: 8px;
+        background: var(--vscode-progressBar-background);
+      }
+      .deviation {
+        border-left: 3px solid var(--vscode-errorForeground);
+        padding-left: 0.5rem;
+        margin: 0.3rem 0;
+      }
+      .deviation.warning {
+        border-color: var(--vscode-editorWarning-foreground);
+      }
+      .deviation.info {
+        border-color: var(--vscode-editorInfo-foreground);
+      }
+      ul.criteria {
+        margin: 0.25rem 0 0.5rem 1rem;
+      }
+      table.tasks {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+      }
+      table.tasks th,
+      table.tasks td {
+        border-bottom: 1px solid var(--vscode-panel-border);
+        padding: 0.2rem 0.3rem;
+      }
+      table.tasks th {
+        text-align: left;
+        color: var(--vscode-descriptionForeground);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h2>Spec Telemetry</h2>
+      <div>
+        <span class="phase-pill" id="active-phase">Phase: -</span>
+        <button class="refresh" id="refresh">Refresh</button>
+      </div>
+    </div>
+    <div id="content">Loading spec telemetry...</div>
+    <script nonce="${nonce}">
+      const vscode = acquireVsCodeApi();
+
+      const severityClass = severity => {
+        switch (severity) {
+          case 'critical':
+            return 'deviation';
+          case 'warning':
+            return 'deviation warning';
+          default:
+            return 'deviation info';
+        }
+      };
+
+      const escapeHtml = value => {
+        if (!value) {
+          return '';
+        }
+        return value
+          .toString()
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+      };
+
+      const renderProgress = progress => {
+        if (!progress || progress.totalTasks === 0) {
+          return '<div class="progress-bar"><span style="width:0%"></span></div>';
+        }
+        const percent = Math.round((progress.touchedTasks / progress.totalTasks) * 100);
+        return (
+          '<div class="progress-bar"><span style="width:' +
+          percent +
+          '%"></span></div><div>' +
+          percent +
+          '% overall coverage (' +
+          progress.touchedTasks +
+          '/' +
+          progress.totalTasks +
+          ')</div>'
+        );
+      };
+
+      const renderReport = report => {
+        const acceptance = report.acceptanceCriteria
+          .map(item => '\n              <li>' + escapeHtml(item) + '</li>')
+          .join('');
+
+        const deviations = report.deviations.length
+          ? report.deviations
+              .map(
+                deviation =>
+                  '\n              <div class="' +
+                  severityClass(deviation.severity) +
+                  '">\n                <strong>' +
+                  escapeHtml(deviation.type) +
+                  '</strong> &mdash; ' +
+                  escapeHtml(deviation.message) +
+                  '\n              </div>'
+              )
+              .join('')
+          : '<div class="deviation info">No discrepancies detected.</div>';
+
+        const rows = report.alignedTasks
+          .map(task => {
+            const status = task.gitStatus?.status || 'clean';
+            return (
+              '\n              <tr>\n                <td>' +
+              escapeHtml(task.taskId) +
+              '</td>\n                <td>' +
+              escapeHtml(task.phase) +
+              '</td>\n                <td>' +
+              escapeHtml(task.description) +
+              '</td>\n                <td>' +
+              escapeHtml(status) +
+              '</td>\n              </tr>'
+            );
+          })
+          .join('');
+
+        return (
+          '\n          <div class="report">\n            <h3>' +
+          escapeHtml(report.featureName) +
+          '</h3>\n            ' +
+          renderProgress(report.progress) +
+          '\n            <h4>Acceptance Criteria</h4>\n            <ul class="criteria">' +
+          (acceptance || '<li>No criteria recorded.</li>') +
+          '</ul>\n            <h4>Deviations</h4>\n            ' +
+          deviations +
+          '\n            <h4>Task Alignment</h4>\n            <table class="tasks">\n              <thead>\n                <tr>\n                  <th>ID</th>\n                  <th>Phase</th>\n                  <th>Description</th>\n                  <th>Git Status</th>\n                </tr>\n              </thead>\n              <tbody>' +
+          rows +
+          '</tbody>\n            </table>\n          </div>'
+        );
+      };
+
+      const render = payload => {
+        const phaseEl = document.getElementById('active-phase');
+        if (phaseEl) {
+          phaseEl.textContent = 'Phase: ' + payload.activePhase;
+        }
+
+        const content = document.getElementById('content');
+        if (!payload.reports.length) {
+          content.innerHTML = '<div class="deviation info">No Spec Kit artifacts available yet.</div>';
+          return;
+        }
+
+        content.innerHTML = payload.reports.map(renderReport).join('');
+      };
+
+      window.addEventListener('message', event => {
+        if (event.data && event.data.type === 'spec-sync-report') {
+          render(event.data.payload);
+        }
+      });
+
+      const refreshButton = document.getElementById('refresh');
+      if (refreshButton) {
+        refreshButton.addEventListener('click', () => {
+          vscode.postMessage({ command: 'refresh' });
+        });
+      }
+    </script>
+  </body>
+</html>`;
+  }
+}

--- a/src/spec-kit/specGenerator.ts
+++ b/src/spec-kit/specGenerator.ts
@@ -17,6 +17,7 @@ export interface GeneratedSpec {
   clarificationNeeded: string[];
   functionalRequirements: string[];
   userScenarios: string[];
+  acceptanceCriteria: string[];
   keyEntities: string[];
   constitutionCompliance: ConstitutionCheck;
 }
@@ -120,6 +121,7 @@ export class SpecGenerator {
       clarificationNeeded: clarifications,
       functionalRequirements: specSections.functionalRequirements,
       userScenarios: specSections.userScenarios,
+      acceptanceCriteria: specSections.acceptanceScenarios || [],
       keyEntities: specSections.keyEntities,
       constitutionCompliance: constitutionCheck
     };
@@ -441,6 +443,7 @@ export class SpecGenerator {
       clarificationNeeded: analysis.clarificationNeeded,
       functionalRequirements: analysis.functionalRequirements,
       userScenarios: analysis.userScenarios,
+      acceptanceCriteria: analysis.acceptanceCriteria || analysis.acceptanceScenarios || [],
       keyEntities: analysis.keyEntities,
       constitutionCompliance: analysis.constitutionCompliance
     };
@@ -459,6 +462,7 @@ export class SpecGenerator {
       "clarificationNeeded": ["list of clarifications"],
       "functionalRequirements": ["list of requirements"],
       "userScenarios": ["list of scenarios"],
+      "acceptanceCriteria": ["list of acceptance checks"],
       "keyEntities": ["list of entities"],
       "constitutionCompliance": {
         "passed": boolean,
@@ -479,6 +483,7 @@ export class SpecGenerator {
         clarificationNeeded: [],
         functionalRequirements: [],
         userScenarios: [],
+        acceptanceCriteria: [],
         keyEntities: [],
         constitutionCompliance: { passed: true, violations: [], warnings: [], complexityScore: 5 }
       };

--- a/src/workflow/specSync.ts
+++ b/src/workflow/specSync.ts
@@ -1,0 +1,367 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { SpecKitManager } from '../spec-kit/specKitManager';
+import { GitManager, GitFileDiff, GitDiffStatus } from '../git/gitManager';
+import { logger } from '../utils/logger';
+
+interface TaskGraphNode {
+  id: string;
+  phase: string;
+  description: string;
+  filePath: string;
+  prerequisites: string[];
+  estimatedTime: string;
+  type: string;
+  priority: string;
+}
+
+interface TaskGraphEdge {
+  from: string;
+  to: string;
+  reason?: string;
+}
+
+interface TaskGraphData {
+  metadata: {
+    workflowId: string;
+    featureName: string;
+    generatedAt: string;
+    estimatedDuration: string;
+  };
+  nodes: TaskGraphNode[];
+  edges: TaskGraphEdge[];
+  parallelGroups: Array<{ groupId: string; tasks: string[]; description: string }>;
+  acceptanceCriteria?: string[];
+}
+
+interface AcceptanceData {
+  workflowId: string;
+  featureName: string;
+  acceptanceCriteria: string[];
+  functionalRequirements?: string[];
+  userScenarios?: string[];
+}
+
+interface WorkflowContext {
+  workflowId: string;
+  featureName: string;
+  workspaceDir: string;
+  specsDir: string;
+  taskGraphPath: string;
+  acceptancePath?: string;
+}
+
+export interface SpecAlignedTask {
+  taskId: string;
+  description: string;
+  phase: string;
+  filePath: string;
+  normalizedPath?: string;
+  gitStatus: GitFileDiff;
+}
+
+export interface SpecDeviation {
+  type: 'missingImplementation' | 'phaseDrift' | 'testingLag' | 'acceptanceGap';
+  severity: 'info' | 'warning' | 'critical';
+  message: string;
+  relatedTaskIds?: string[];
+}
+
+export interface SpecSyncReport {
+  workflowId: string;
+  featureName: string;
+  activePhase: string;
+  generatedAt: string;
+  acceptanceCriteria: string[];
+  alignedTasks: SpecAlignedTask[];
+  deviations: SpecDeviation[];
+  progress: {
+    totalTasks: number;
+    touchedTasks: number;
+    currentPhaseTasks: number;
+    currentPhaseTouched: number;
+  };
+}
+
+export class SpecSync {
+  private readonly phaseTaskMapping: Record<string, string[]> = {
+    Planning: ['setup'],
+    Prototyping: ['test', 'implementation'],
+    Testing: ['integration', 'test'],
+    Deployment: ['polish', 'integration'],
+  };
+
+  constructor(
+    private readonly gitManager: GitManager,
+    private readonly specKitManager?: SpecKitManager
+  ) {}
+
+  async generateReports(activePhase: string): Promise<SpecSyncReport[]> {
+    const contexts = await this.resolveWorkflowContexts();
+    const reports: SpecSyncReport[] = [];
+
+    for (const context of contexts) {
+      try {
+        const report = await this.buildReport(context, activePhase);
+        if (report) {
+          reports.push(report);
+        }
+      } catch (error) {
+        logger.error(`SpecSync: failed to build report for ${context.workflowId}: ${error}`);
+      }
+    }
+
+    return reports;
+  }
+
+  private async resolveWorkflowContexts(): Promise<WorkflowContext[]> {
+    const contexts: WorkflowContext[] = [];
+
+    if (this.specKitManager) {
+      for (const workflow of this.specKitManager.getWorkflows()) {
+        const taskGraphPath = path.join(workflow.specsDir, 'task-graph.json');
+        if (!(await this.pathExists(taskGraphPath))) {
+          continue;
+        }
+
+        const acceptancePath = await this.resolveAcceptancePath(workflow.specsDir);
+        contexts.push({
+          workflowId: workflow.id,
+          featureName: workflow.featureName,
+          workspaceDir: workflow.workspaceDir,
+          specsDir: workflow.specsDir,
+          taskGraphPath,
+          acceptancePath,
+        });
+      }
+    }
+
+    if (contexts.length > 0) {
+      return contexts;
+    }
+
+    const workspaceDir =
+      this.gitManager.getWorkspacePath() || vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+    if (!workspaceDir) {
+      return contexts;
+    }
+
+    const specsDir = path.join(workspaceDir, 'specs');
+    try {
+      const entries = await fs.promises.readdir(specsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        const directory = path.join(specsDir, entry.name);
+        const taskGraphPath = path.join(directory, 'task-graph.json');
+        if (!(await this.pathExists(taskGraphPath))) {
+          continue;
+        }
+
+        let metadata: TaskGraphData['metadata'] | undefined;
+        try {
+          const raw = await fs.promises.readFile(taskGraphPath, 'utf8');
+          const parsed = JSON.parse(raw) as TaskGraphData;
+          metadata = parsed.metadata;
+        } catch (error) {
+          logger.warn(`SpecSync: unable to parse task graph metadata for ${directory}: ${error}`);
+        }
+
+        contexts.push({
+          workflowId: metadata?.workflowId || entry.name,
+          featureName: metadata?.featureName || entry.name,
+          workspaceDir,
+          specsDir: directory,
+          taskGraphPath,
+          acceptancePath: await this.resolveAcceptancePath(directory),
+        });
+      }
+    } catch (error) {
+      logger.warn(`SpecSync: unable to read specs directory: ${error}`);
+    }
+
+    return contexts;
+  }
+
+  private async buildReport(
+    context: WorkflowContext,
+    activePhase: string
+  ): Promise<SpecSyncReport | null> {
+    try {
+      const raw = await fs.promises.readFile(context.taskGraphPath, 'utf8');
+      const graph = JSON.parse(raw) as TaskGraphData;
+
+      const acceptanceData = await this.loadAcceptanceData(context.acceptancePath);
+      const acceptanceCriteria =
+        acceptanceData?.acceptanceCriteria || graph.acceptanceCriteria || [];
+
+      const normalizedPaths = graph.nodes
+        .map(node => this.normalizeTaskPath(node.filePath, context.workspaceDir))
+        .filter((value): value is string => Boolean(value));
+
+      const gitDiffs = await this.gitManager.getFileDiffs(normalizedPaths);
+
+      const alignedTasks: SpecAlignedTask[] = graph.nodes.map(node => {
+        const normalizedPath = this.normalizeTaskPath(node.filePath, context.workspaceDir) || undefined;
+        const gitStatus: GitFileDiff = normalizedPath
+          ? gitDiffs[normalizedPath] || { status: 'clean' }
+          : { status: 'unknown' };
+        return {
+          taskId: node.id,
+          description: node.description,
+          phase: node.phase,
+          filePath: node.filePath,
+          normalizedPath,
+          gitStatus,
+        };
+      });
+
+      const relevantPhases = this.phaseTaskMapping[activePhase] || [];
+      const currentPhaseTasks = alignedTasks.filter(task => relevantPhases.includes(task.phase));
+      const currentPhaseTouched = currentPhaseTasks.filter(task => this.isTouched(task.gitStatus.status)).length;
+      const touchedTasks = alignedTasks.filter(task => this.isTouched(task.gitStatus.status)).length;
+
+      const deviations = this.detectDeviations(
+        alignedTasks,
+        relevantPhases,
+        activePhase,
+        acceptanceCriteria
+      );
+
+      return {
+        workflowId: context.workflowId,
+        featureName: context.featureName,
+        activePhase,
+        generatedAt: new Date().toISOString(),
+        acceptanceCriteria,
+        alignedTasks,
+        deviations,
+        progress: {
+          totalTasks: alignedTasks.length,
+          touchedTasks,
+          currentPhaseTasks: currentPhaseTasks.length,
+          currentPhaseTouched,
+        },
+      };
+    } catch (error) {
+      logger.error(`SpecSync: failed to load task graph for ${context.workflowId}: ${error}`);
+      return null;
+    }
+  }
+
+  private detectDeviations(
+    alignedTasks: SpecAlignedTask[],
+    relevantPhases: string[],
+    activePhase: string,
+    acceptanceCriteria: string[]
+  ): SpecDeviation[] {
+    const deviations: SpecDeviation[] = [];
+
+    for (const task of alignedTasks) {
+      if (relevantPhases.includes(task.phase) && !this.isTouched(task.gitStatus.status)) {
+        deviations.push({
+          type: 'missingImplementation',
+          severity: 'warning',
+          message: `Task ${task.taskId} (${task.description}) has not started in active phase ${activePhase}.`,
+          relatedTaskIds: [task.taskId],
+        });
+      }
+
+      if (!relevantPhases.includes(task.phase) && this.isTouched(task.gitStatus.status)) {
+        deviations.push({
+          type: 'phaseDrift',
+          severity: 'critical',
+          message: `Task ${task.taskId} (${task.description}) is progressing outside of the active phase (${activePhase}).`,
+          relatedTaskIds: [task.taskId],
+        });
+      }
+    }
+
+    const implementationTouched = alignedTasks.filter(
+      task => task.phase === 'implementation' && this.isTouched(task.gitStatus.status)
+    );
+    const testTouched = alignedTasks.filter(
+      task => task.phase === 'test' && this.isTouched(task.gitStatus.status)
+    );
+
+    if (implementationTouched.length > 0 && testTouched.length === 0) {
+      deviations.push({
+        type: 'testingLag',
+        severity: 'critical',
+        message:
+          'Implementation activity detected without corresponding test updates. Ensure TDD sequence is respected.',
+        relatedTaskIds: implementationTouched.map(task => task.taskId),
+      });
+    }
+
+    if (acceptanceCriteria.length > 0 && testTouched.length === 0 && relevantPhases.includes('test')) {
+      deviations.push({
+        type: 'acceptanceGap',
+        severity: 'warning',
+        message: 'Acceptance criteria defined but no test tasks show progress yet.',
+      });
+    }
+
+    return deviations;
+  }
+
+  private isTouched(status: GitDiffStatus): boolean {
+    return status !== 'clean' && status !== 'unknown';
+  }
+
+  private async resolveAcceptancePath(specsDir: string): Promise<string | undefined> {
+    const acceptancePath = path.join(specsDir, 'acceptance-criteria.json');
+    if (await this.pathExists(acceptancePath)) {
+      return acceptancePath;
+    }
+    return undefined;
+  }
+
+  private async loadAcceptanceData(
+    acceptancePath?: string
+  ): Promise<AcceptanceData | undefined> {
+    if (!acceptancePath) {
+      return undefined;
+    }
+
+    try {
+      const raw = await fs.promises.readFile(acceptancePath, 'utf8');
+      return JSON.parse(raw) as AcceptanceData;
+    } catch (error) {
+      logger.warn(`SpecSync: unable to parse acceptance criteria at ${acceptancePath}: ${error}`);
+      return undefined;
+    }
+  }
+
+  private normalizeTaskPath(filePath: string, workspaceDir: string): string | null {
+    if (!filePath || filePath === 'multiple') {
+      return null;
+    }
+
+    const cleaned = filePath.replace(/^\.\//, '').trim();
+    if (!cleaned) {
+      return null;
+    }
+
+    const absolute = path.isAbsolute(cleaned) ? cleaned : path.join(workspaceDir, cleaned);
+    const relative = path.relative(workspaceDir, absolute).replace(/\\/g, '/');
+
+    if (!relative || relative.startsWith('..')) {
+      return null;
+    }
+
+    return relative;
+  }
+
+  private async pathExists(targetPath: string): Promise<boolean> {
+    try {
+      await fs.promises.access(targetPath, fs.constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- emit machine-readable acceptance criteria and task graph JSON alongside existing Spec Kit markdown outputs
- add SpecSync workflow analysis to align tasks with active phases and flag git-based deviations
- introduce a Spec Telemetry dashboard webview that visualizes spec progress and feeds discrepancies back to RL and collaboration engines

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_b_68ce3e161a74832c9370062a6b647cc7