### PR TITLE
Add swarm telemetry pipeline and workflow arbitration controls

### DIFF
--- a/media/ignition.js
+++ b/media/ignition.js
@@ -1,0 +1,187 @@
+const vscode = acquireVsCodeApi();
+
+function submitIdea() {
+  const ideaInput = document.getElementById('ideaInput');
+  const optionSelect = document.getElementById('promptOption');
+  const customBox = document.getElementById('customText');
+  if (!ideaInput || !optionSelect) {
+    return;
+  }
+
+  let idea = ideaInput.value.trim();
+  const option = optionSelect.value;
+
+  if (option === 'custom' && customBox) {
+    const custom = customBox.value.trim();
+    if (custom) {
+      idea = `${idea}\n\nCustom Refinement:\n${custom}`;
+    }
+  }
+
+  vscode.postMessage({ type: 'submitIdea', idea, option });
+}
+
+function toggleCustomBox() {
+  const optionSelect = document.getElementById('promptOption');
+  const customContainer = document.getElementById('customBox');
+  if (!optionSelect || !customContainer) {
+    return;
+  }
+
+  customContainer.style.display = optionSelect.value === 'custom' ? 'block' : 'none';
+}
+
+function renderArbitrationControls(modes) {
+  const container = document.getElementById('arbitrationControls');
+  if (!container) {
+    return;
+  }
+
+  container.innerHTML = '';
+  Object.entries(modes).forEach(([phase, mode]) => {
+    const row = document.createElement('div');
+    row.className = 'arbitration-control';
+
+    const phaseLabel = document.createElement('div');
+    phaseLabel.className = 'arbitration-phase';
+    phaseLabel.textContent = phase;
+
+    const toggleWrapper = document.createElement('label');
+    toggleWrapper.className = 'toggle';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.dataset.phase = phase;
+    input.checked = mode === 'autonomous';
+
+    const slider = document.createElement('span');
+    slider.className = 'slider';
+
+    toggleWrapper.appendChild(input);
+    toggleWrapper.appendChild(slider);
+
+    const modeLabel = document.createElement('div');
+    modeLabel.className = 'arbitration-mode-label';
+    modeLabel.textContent = mode === 'autonomous' ? 'Autonomous' : 'Human-in-the-loop';
+
+    input.addEventListener('change', () => {
+      const newMode = input.checked ? 'autonomous' : 'human';
+      modeLabel.textContent = input.checked ? 'Autonomous' : 'Human-in-the-loop';
+      vscode.postMessage({ type: 'setArbitrationMode', phase, mode: newMode });
+    });
+
+    row.appendChild(phaseLabel);
+    row.appendChild(toggleWrapper);
+    row.appendChild(modeLabel);
+    container.appendChild(row);
+  });
+}
+
+function appendTelemetryCard(event) {
+  const feed = document.getElementById('telemetryFeed');
+  if (!feed) {
+    return;
+  }
+
+  const card = document.createElement('div');
+  card.className = `telemetry-card telemetry-${event.type}`;
+
+  const header = document.createElement('div');
+  header.className = 'telemetry-header';
+  const phase = event.payload?.phase ?? 'Unknown phase';
+  const timestamp = new Date(event.payload?.timestamp ?? Date.now()).toLocaleTimeString();
+  header.textContent = `${phase} • ${event.type.replace(/_/g, ' ')} • ${timestamp}`;
+  card.appendChild(header);
+
+  const summary = document.createElement('div');
+  summary.className = 'telemetry-summary';
+  if (event.type === 'round') {
+    summary.textContent = event.payload?.summary ?? 'Round completed';
+  } else if (event.type === 'session_complete') {
+    summary.textContent = event.payload?.summary ?? 'Session completed';
+  } else if (event.type === 'session_summary') {
+    summary.textContent = event.payload?.summary ?? 'Session summary';
+  } else if (event.type === 'arbitration_mode_updated') {
+    summary.textContent = `Arbitration for ${event.payload?.phase} set to ${event.payload?.mode}`;
+  } else {
+    summary.textContent = event.payload?.summary ?? 'Swarm update';
+  }
+  card.appendChild(summary);
+
+  if (event.type === 'round' && event.payload?.outcome) {
+    const metrics = document.createElement('div');
+    metrics.className = 'telemetry-metrics';
+    const outcome = event.payload.outcome;
+    metrics.innerHTML = `Consensus: <strong>${Math.round(outcome.consensusStrength)}%</strong> • ` +
+      `Engagement: ${outcome.metrics.participantEngagement}% • Critique: ${outcome.metrics.critiqueCoverage}%`;
+    card.appendChild(metrics);
+
+    if (outcome.suggestedPatches?.length) {
+      const list = document.createElement('ul');
+      list.className = 'telemetry-patches';
+      outcome.suggestedPatches.slice(0, 3).forEach(patch => {
+        const item = document.createElement('li');
+        item.textContent = `${patch.priority.toUpperCase()}: ${patch.description}`;
+        list.appendChild(item);
+      });
+      card.appendChild(list);
+    }
+  }
+
+  if (event.type === 'session_complete') {
+    const footer = document.createElement('div');
+    footer.className = 'telemetry-footer';
+    footer.textContent = `Quality score: ${event.payload?.qualityScore ?? 0}`;
+    card.appendChild(footer);
+  }
+
+  feed.prepend(card);
+  while (feed.children.length > 20) {
+    feed.removeChild(feed.lastChild);
+  }
+}
+
+window.addEventListener('message', event => {
+  const { type, payload } = event.data;
+  switch (type) {
+    case 'arbitrationModes':
+      renderArbitrationControls(payload || {});
+      break;
+    case 'swarmTelemetry':
+      appendTelemetryCard(payload);
+      if (payload?.type === 'arbitration_mode_updated' && payload?.payload?.phase && payload?.payload?.mode) {
+        const checkbox = document.querySelector(`input[data-phase="${payload.payload.phase}"]`);
+        if (checkbox instanceof HTMLInputElement) {
+          checkbox.checked = payload.payload.mode === 'autonomous';
+          const label = checkbox.parentElement?.parentElement?.querySelector('.arbitration-mode-label');
+          if (label) {
+            label.textContent = payload.payload.mode === 'autonomous' ? 'Autonomous' : 'Human-in-the-loop';
+          }
+        }
+      }
+      break;
+    case 'swarmTelemetryBatch':
+      (payload || []).forEach((entry) => {
+        appendTelemetryCard({ type: 'round', payload: entry });
+      });
+      break;
+    default:
+      break;
+  }
+});
+
+function registerEventHandlers() {
+  const optionSelect = document.getElementById('promptOption');
+  const submitButton = document.getElementById('submitIdeaButton');
+  if (optionSelect) {
+    optionSelect.addEventListener('change', toggleCustomBox);
+  }
+  if (submitButton) {
+    submitButton.addEventListener('click', submitIdea);
+  }
+
+  toggleCustomBox();
+}
+
+registerEventHandlers();
+vscode.postMessage({ type: 'requestInitialState' });

--- a/media/styles.css
+++ b/media/styles.css
@@ -61,3 +61,127 @@ label {
   margin: 8px 0 4px 0;
   font-weight: 500;
 }
+
+.arbitration-section,
+.telemetry-section {
+  margin-top: 20px;
+  padding: 12px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 6px;
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.arbitration-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.arbitration-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 4px;
+}
+
+.arbitration-phase {
+  font-weight: 600;
+}
+
+.arbitration-hint {
+  font-size: 12px;
+  margin-bottom: 10px;
+  opacity: 0.7;
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 22px;
+}
+
+.toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--vscode-button-secondaryBackground);
+  transition: 0.3s;
+  border-radius: 22px;
+}
+
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background-color: var(--vscode-editor-background);
+  transition: 0.3s;
+  border-radius: 50%;
+}
+
+.toggle input:checked + .slider {
+  background-color: var(--vscode-button-background);
+}
+
+.toggle input:checked + .slider:before {
+  transform: translateX(22px);
+}
+
+.telemetry-feed {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 10px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.telemetry-card {
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 4px;
+  padding: 10px;
+  background-color: rgba(0, 0, 0, 0.25);
+}
+
+.telemetry-header {
+  font-size: 12px;
+  opacity: 0.8;
+  margin-bottom: 6px;
+}
+
+.telemetry-summary {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.telemetry-metrics {
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.telemetry-patches {
+  margin: 0;
+  padding-left: 16px;
+  font-size: 12px;
+}
+
+.telemetry-footer {
+  font-size: 12px;
+  opacity: 0.7;
+  margin-top: 6px;
+}

--- a/src/collaboration/types/collaborationTypes.ts
+++ b/src/collaboration/types/collaborationTypes.ts
@@ -227,8 +227,37 @@ export interface CollaborationConfig {
 /**
  * Events emitted by the collaboration system
  */
+export interface DissentVector {
+  sourceContribution: string;
+  targetContribution: string;
+  originator: string;
+  severity: 'low' | 'medium' | 'high';
+  summary: string;
+}
+
+export interface SuggestedPatch {
+  description: string;
+  originatingContribution: string;
+  confidence: number;
+  priority: 'low' | 'medium' | 'high';
+  affectedAreas: string[];
+}
+
+export interface RoundOutcomeTelemetry {
+  roundId: string;
+  roundType: RoundType;
+  consensusStrength: number;
+  dissentVectors: DissentVector[];
+  suggestedPatches: SuggestedPatch[];
+  metrics: {
+    averageConfidence: number;
+    critiqueCoverage: number;
+    participantEngagement: number;
+  };
+}
+
 export interface CollaborationEvent {
-  type: 'session_started' | 'round_started' | 'contribution_received' | 
+  type: 'session_started' | 'round_started' | 'round_completed' | 'contribution_received' |
         'consensus_reached' | 'timeout_warning' | 'session_completed' | 'error';
   sessionId: string;
   timestamp: Date;

--- a/src/providers/projectIgnition.ts
+++ b/src/providers/projectIgnition.ts
@@ -4,13 +4,22 @@ import { WorkflowManager } from '../workflow/workflowManager';
 export class ProjectIgnitionProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'astraforge.projectIgnition';
   private _view?: vscode.Webview;
+  private readonly _telemetryListener: (event: any) => void;
 
   constructor(
     private readonly _extensionUri: vscode.Uri,
     private readonly _workflowManager: WorkflowManager
   ) {
     // Initialize provider with extension URI and workflow manager
-    // These parameters are used in the class methods
+    this._telemetryListener = (event: any) => {
+      if (!this._view) {
+        return;
+      }
+
+      this._view.postMessage({ type: 'swarmTelemetry', payload: event });
+    };
+
+    this._workflowManager.on('swarm_telemetry', this._telemetryListener);
   }
 
   public resolveWebviewView(
@@ -28,11 +37,27 @@ export class ProjectIgnitionProvider implements vscode.WebviewViewProvider {
 
     webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
 
+    this.sendInitialState(webviewView.webview);
+
+    webviewView.onDidDispose(() => this.dispose());
+
     webviewView.webview.onDidReceiveMessage(async data => {
-      if (data.type === 'submitIdea') {
-        this._workflowManager.startWorkflow(data.idea, data.option);
+      switch (data.type) {
+        case 'submitIdea':
+          this._workflowManager.startWorkflow(data.idea, data.option);
+          break;
+        case 'setArbitrationMode':
+          this._workflowManager.setPhaseArbitrationMode(data.phase, data.mode);
+          break;
+        case 'requestInitialState':
+          this.sendInitialState(webviewView.webview);
+          break;
       }
     });
+  }
+
+  public dispose(): void {
+    this._view = undefined;
   }
 
   private _getHtmlForWebview(webview: vscode.Webview) {
@@ -59,10 +84,32 @@ export class ProjectIgnitionProvider implements vscode.WebviewViewProvider {
   <div id="customBox" style="display:none;">
     <textarea id="customText"></textarea>
   </div>
-  <button onclick="submitIdea()">Submit</button>
+  <button id="submitIdeaButton">Submit</button>
+
+  <section class="arbitration-section">
+    <h2>Phase Arbitration</h2>
+    <p class="arbitration-hint">Toggle autonomous arbitration to let the swarm finalize a phase without manual approval.</p>
+    <div id="arbitrationControls" class="arbitration-controls"></div>
+  </section>
+
+  <section class="telemetry-section">
+    <h2>Swarm Telemetry</h2>
+    <div id="telemetryFeed" class="telemetry-feed"></div>
+  </section>
+
   <div id="progressTracker"></div>
   <script src="${scriptUri}"></script>
 </body>
 </html>`;
+  }
+
+  private sendInitialState(webview: vscode.Webview): void {
+    const arbitrationModes = this._workflowManager.getPhaseArbitrationModes();
+    webview.postMessage({ type: 'arbitrationModes', payload: arbitrationModes });
+
+    const recentTelemetry = this._workflowManager.getRecentTelemetry();
+    if (recentTelemetry.length > 0) {
+      webview.postMessage({ type: 'swarmTelemetryBatch', payload: recentTelemetry });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add telemetry-rich collaboration events, dissent vectors, and suggested patch structures for collaboration rounds
- upgrade the collaborative session manager and workflow manager to orchestrate critique/synthesis rounds and broadcast swarm metrics to the UI
- surface swarm telemetry and arbitration toggles in the Project Ignition view with new webview logic and styles

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_b_68ce3dfc34f8832ca213c47b3e791b61