### PR TITLE
feat: introduce agent economy routing and llm metrics

### DIFF
--- a/src/llm/agentEconomy.ts
+++ b/src/llm/agentEconomy.ts
@@ -1,0 +1,275 @@
+import { LLMManager } from './llmManager';
+import { LLMConfig, ProviderMetricsSummary } from './interfaces';
+
+export interface EconomyRequestContext {
+  requestId: string;
+  prompt: string;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  costBudget?: number;
+  contextType: 'workflow' | 'collaboration';
+  expectedParticipants?: number;
+  metadata?: Record<string, any>;
+}
+
+export interface RoutingAllocation {
+  provider: LLMConfig['provider'];
+  model: string;
+  role: 'primary' | 'secondary' | 'support';
+  weight: number;
+  maxTokens: number;
+  expectedTokens: number;
+  expectedCostUsd: number;
+  expectedLatencyMs: number;
+  score: number;
+  capacityScore: number;
+}
+
+export interface RoutingPlan {
+  requestId: string;
+  contextType: EconomyRequestContext['contextType'];
+  priority: EconomyRequestContext['priority'];
+  budgetTokens?: number;
+  totalEstimatedTokens: number;
+  totalEstimatedCostUsd: number;
+  allocations: RoutingAllocation[];
+  createdAt: number;
+  metadata?: Record<string, any>;
+}
+
+interface CandidateScore {
+  config: LLMConfig;
+  metrics?: ProviderMetricsSummary;
+  score: number;
+  normalized: {
+    latency: number;
+    cost: number;
+    reliability: number;
+  };
+  avgTokens: number;
+  avgLatency: number;
+  avgCost: number;
+}
+
+export class AgentEconomy {
+  constructor(private llmManager: LLMManager) {}
+
+  createRoutingPlan(context: EconomyRequestContext): RoutingPlan {
+    const configs = this.llmManager.getPanelConfigurations();
+    const createdAt = Date.now();
+
+    if (configs.length === 0) {
+      return {
+        requestId: context.requestId,
+        contextType: context.contextType,
+        priority: context.priority,
+        budgetTokens: context.costBudget,
+        totalEstimatedTokens: 0,
+        totalEstimatedCostUsd: 0,
+        allocations: [],
+        createdAt,
+        metadata: {
+          message: 'No providers configured for routing',
+          ...context.metadata
+        }
+      };
+    }
+
+    const providerMetrics = this.llmManager.getProviderMetricsSummary();
+    const metricsMap = new Map<string, ProviderMetricsSummary>();
+    providerMetrics.forEach(summary => {
+      metricsMap.set(`${summary.provider}:${summary.model}`, summary);
+    });
+
+    const candidates = configs.map(config => {
+      const metrics = metricsMap.get(`${config.provider}:${config.model}`);
+      const avgLatency = metrics?.avgLatencyMs ?? 2500;
+      const avgTokens = metrics && metrics.successfulRequests > 0
+        ? metrics.totalTokens / metrics.successfulRequests
+        : Math.min(config.maxTokens ?? 1200, 1200);
+      const avgCost = metrics?.avgCostUsd ?? this.llmManager.estimateCostFromTotalTokens(config.provider, avgTokens);
+
+      return {
+        config,
+        metrics,
+        avgLatency,
+        avgTokens,
+        avgCost,
+        score: 0,
+        normalized: { latency: 0, cost: 0, reliability: 0 }
+      } as CandidateScore;
+    });
+
+    const latencyValues = candidates.map(candidate => candidate.avgLatency);
+    const costValues = candidates.map(candidate => candidate.avgCost);
+    const reliabilityValues = candidates.map(candidate => candidate.metrics?.successRate ?? 0.7);
+
+    const maxLatency = Math.max(...latencyValues);
+    const minLatency = Math.min(...latencyValues);
+    const maxCost = Math.max(...costValues);
+    const minCost = Math.min(...costValues);
+    const maxReliability = Math.max(...reliabilityValues);
+    const minReliability = Math.min(...reliabilityValues);
+
+    const weights = this.getPriorityWeights(context.priority);
+
+    candidates.forEach((candidate, index) => {
+      const reliability = candidate.metrics?.successRate ?? 0.7;
+      const normalizedLatency = maxLatency === minLatency
+        ? 1
+        : (maxLatency - candidate.avgLatency) / (maxLatency - minLatency);
+      const normalizedCost = maxCost === minCost
+        ? 1
+        : (maxCost - candidate.avgCost) / (maxCost - minCost);
+      const normalizedReliability = maxReliability === minReliability
+        ? 1
+        : (reliability - minReliability) / (maxReliability - minReliability);
+
+      candidate.normalized = {
+        latency: normalizedLatency,
+        cost: normalizedCost,
+        reliability: normalizedReliability
+      };
+
+      candidate.score =
+        normalizedLatency * weights.latency +
+        normalizedCost * weights.cost +
+        normalizedReliability * weights.reliability +
+        this.getRoleBonus(index, context.priority);
+    });
+
+    const sortedCandidates = candidates.sort((a, b) => b.score - a.score);
+
+    const budgetTokens = typeof context.costBudget === 'number' ? context.costBudget : Number.POSITIVE_INFINITY;
+    let remainingBudget = budgetTokens;
+    const selected: { candidate: CandidateScore; expectedTokens: number }[] = [];
+    const tokenScaling = this.getPriorityTokenScaling(context.priority);
+
+    for (const candidate of sortedCandidates) {
+      const estimatedTokens = Math.max(200, Math.round(candidate.avgTokens * tokenScaling));
+      const maxTokens = candidate.config.maxTokens ?? Math.max(estimatedTokens, 4000);
+      const cappedTokens = Math.min(estimatedTokens, maxTokens);
+
+      if (selected.length === 0 || !Number.isFinite(remainingBudget) || remainingBudget >= cappedTokens) {
+        selected.push({ candidate, expectedTokens: cappedTokens });
+        if (Number.isFinite(remainingBudget)) {
+          remainingBudget = Math.max(0, remainingBudget - cappedTokens);
+        }
+      }
+
+      if (selected.length >= (context.expectedParticipants || configs.length)) {
+        break;
+      }
+    }
+
+    if (selected.length === 0) {
+      const topCandidate = sortedCandidates[0];
+      const fallbackTokens = Math.max(200, Math.round(topCandidate.avgTokens * tokenScaling));
+      selected.push({ candidate: topCandidate, expectedTokens: fallbackTokens });
+    }
+
+    const allocations = this.buildAllocations(selected);
+    const totalEstimatedTokens = allocations.reduce((sum, allocation) => sum + allocation.expectedTokens, 0);
+    const totalEstimatedCostUsd = allocations.reduce((sum, allocation) => sum + allocation.expectedCostUsd, 0);
+
+    return {
+      requestId: context.requestId,
+      contextType: context.contextType,
+      priority: context.priority,
+      budgetTokens: context.costBudget,
+      totalEstimatedTokens,
+      totalEstimatedCostUsd,
+      allocations,
+      createdAt,
+      metadata: context.metadata
+    };
+  }
+
+  private buildAllocations(selected: { candidate: CandidateScore; expectedTokens: number }[]): RoutingAllocation[] {
+    const supports = Math.max(0, selected.length - 2);
+    const primaryWeight = 0.5;
+    const secondaryWeight = selected.length > 1 ? 0.3 : 0;
+    const supportWeightPool = Math.max(0, 1 - (primaryWeight + secondaryWeight));
+    const supportWeight = supports > 0 ? supportWeightPool / supports : 0;
+
+    return selected.map(({ candidate, expectedTokens }, index) => {
+      const role = this.determineRole(index);
+      const weight =
+        role === 'primary'
+          ? primaryWeight
+          : role === 'secondary'
+          ? secondaryWeight
+          : supportWeight;
+      const expectedCostUsd = this.llmManager.estimateCostFromTotalTokens(
+        candidate.config.provider,
+        expectedTokens
+      );
+      const capacityScore = Math.max(
+        0.1,
+        Math.min(1, 1 - expectedTokens / Math.max(candidate.config.maxTokens ?? expectedTokens * 2, 1))
+      );
+
+      return {
+        provider: candidate.config.provider,
+        model: candidate.config.model,
+        role,
+        weight,
+        maxTokens: candidate.config.maxTokens ?? expectedTokens,
+        expectedTokens,
+        expectedCostUsd,
+        expectedLatencyMs: candidate.avgLatency,
+        score: Number(candidate.score.toFixed(3)),
+        capacityScore: Number(capacityScore.toFixed(3))
+      };
+    });
+  }
+
+  private determineRole(index: number): RoutingAllocation['role'] {
+    if (index === 0) {
+      return 'primary';
+    }
+    if (index === 1) {
+      return 'secondary';
+    }
+    return 'support';
+  }
+
+  private getPriorityWeights(priority: EconomyRequestContext['priority']): {
+    latency: number;
+    cost: number;
+    reliability: number;
+  } {
+    switch (priority) {
+      case 'critical':
+        return { latency: 0.45, cost: 0.2, reliability: 0.35 };
+      case 'high':
+        return { latency: 0.4, cost: 0.25, reliability: 0.35 };
+      case 'low':
+        return { latency: 0.25, cost: 0.45, reliability: 0.3 };
+      default:
+        return { latency: 0.3, cost: 0.35, reliability: 0.35 };
+    }
+  }
+
+  private getPriorityTokenScaling(priority: EconomyRequestContext['priority']): number {
+    switch (priority) {
+      case 'critical':
+        return 1.4;
+      case 'high':
+        return 1.2;
+      case 'low':
+        return 0.8;
+      default:
+        return 1;
+    }
+  }
+
+  private getRoleBonus(index: number, priority: EconomyRequestContext['priority']): number {
+    if (index === 0) {
+      return priority === 'critical' ? 0.1 : 0.05;
+    }
+    if (index === 1) {
+      return priority === 'low' ? 0.02 : 0.04;
+    }
+    return 0;
+  }
+}

--- a/src/llm/interfaces.ts
+++ b/src/llm/interfaces.ts
@@ -22,6 +22,34 @@ export interface LLMResponse {
   metadata?: Record<string, any>;
 }
 
+export interface LLMRequestMetric {
+  provider: LLMConfig['provider'];
+  model: string;
+  success: boolean;
+  timestamp: number;
+  latencyMs: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  requestId?: string;
+  errorMessage?: string;
+}
+
+export interface ProviderMetricsSummary {
+  provider: LLMConfig['provider'];
+  model: string;
+  totalRequests: number;
+  successfulRequests: number;
+  successRate: number;
+  avgLatencyMs: number;
+  avgCostUsd: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  lastUpdated: number;
+}
+
 export interface LLMProvider {
   /**
    * Query the LLM with a prompt

--- a/src/llm/llmManager.ts
+++ b/src/llm/llmManager.ts
@@ -4,7 +4,13 @@
  */
 
 import * as vscode from 'vscode';
-import { LLMConfig, LLMProvider, LLMResponse } from './interfaces';
+import {
+  LLMConfig,
+  LLMProvider,
+  LLMRequestMetric,
+  LLMResponse,
+  ProviderMetricsSummary
+} from './interfaces';
 import { createProvider } from './providers';
 import { LLMCache } from './cache';
 
@@ -13,6 +19,9 @@ export class LLMManager {
   private providers = new Map<string, LLMProvider>();
   private cache: LLMCache;
   private readonly maxConcurrentRequests: number;
+  private readonly maxMetricsRetention = 500;
+  private readonly providerPricing: Record<LLMConfig['provider'], { prompt: number; completion: number }>;
+  private requestMetrics: LLMRequestMetric[] = [];
 
   constructor() {
     const panelConfig = vscode.workspace
@@ -28,6 +37,13 @@ export class LLMManager {
     this.maxConcurrentRequests = vscode.workspace
       .getConfiguration('astraforge')
       .get('maxConcurrentRequests', 3);
+
+    this.providerPricing = {
+      OpenAI: { prompt: 0.03, completion: 0.06 },
+      Anthropic: { prompt: 0.025, completion: 0.05 },
+      xAI: { prompt: 0.02, completion: 0.04 },
+      OpenRouter: { prompt: 0.02, completion: 0.04 }
+    };
 
     this.initializeProviders();
   }
@@ -52,10 +68,58 @@ export class LLMManager {
     }
   }
 
+  private recordMetric(
+    config: LLMConfig,
+    latencyMs: number,
+    usage: LLMResponse['usage'] | undefined,
+    success: boolean,
+    error: unknown,
+    requestId?: string
+  ): void {
+    const promptTokens = usage?.promptTokens ?? 0;
+    const completionTokens = usage?.completionTokens ?? 0;
+    const totalTokens = usage?.totalTokens ?? promptTokens + completionTokens;
+    const costUsd = success ? this.calculateCost(config.provider, promptTokens, completionTokens) : 0;
+
+    const metric: LLMRequestMetric = {
+      provider: config.provider,
+      model: config.model,
+      success,
+      timestamp: Date.now(),
+      latencyMs,
+      promptTokens,
+      completionTokens,
+      totalTokens,
+      costUsd,
+      requestId,
+      errorMessage: success ? undefined : error instanceof Error ? error.message : String(error)
+    };
+
+    this.requestMetrics.push(metric);
+    if (this.requestMetrics.length > this.maxMetricsRetention) {
+      this.requestMetrics = this.requestMetrics.slice(-this.maxMetricsRetention);
+    }
+  }
+
+  private calculateCost(
+    provider: LLMConfig['provider'],
+    promptTokens: number,
+    completionTokens: number
+  ): number {
+    const pricing = this.providerPricing[provider];
+    if (!pricing) {
+      return 0;
+    }
+
+    const promptCost = (promptTokens * pricing.prompt) / 1000;
+    const completionCost = (completionTokens * pricing.completion) / 1000;
+    return Number((promptCost + completionCost).toFixed(6));
+  }
+
   /**
    * Query a specific LLM by index with caching and error handling
    */
-  async queryLLM(index: number, prompt: string): Promise<string> {
+  async queryLLM(index: number, prompt: string, requestId?: string): Promise<string> {
     const config = this.panel[index];
     if (!config) {
       return 'No LLM configured at index ' + index;
@@ -72,6 +136,8 @@ export class LLMManager {
       return 'Rate limit exceeded. Please try again later.';
     }
 
+    const startTime = Date.now();
+
     try {
       const provider = this.providers.get(config.provider);
       if (!provider) {
@@ -79,17 +145,23 @@ export class LLMManager {
       }
 
       const response: LLMResponse = await provider.query(prompt, config);
+      const latency = Date.now() - startTime;
 
       // Cache the response
       this.cache.set(prompt, config.provider, config.model, response.content, response.usage);
 
+      this.recordMetric(config, latency, response.usage, true, undefined, requestId);
+
       return response.content;
     } catch (error: any) {
+      const latency = Date.now() - startTime;
+      this.recordMetric(config, latency, undefined, false, error, requestId);
       vscode.window.showErrorMessage(`LLM query failed: ${error.message}. Falling back...`);
 
       // Fallback to primary LLM
       if (index !== 0) {
-        return this.queryLLM(0, prompt);
+        const fallbackRequestId = requestId ? `${requestId}:fallback` : undefined;
+        return this.queryLLM(0, prompt, fallbackRequestId);
       }
 
       return `Error: ${error.message}`;
@@ -99,8 +171,15 @@ export class LLMManager {
   /**
    * Parallel voting system with improved accuracy and fuzzy matching
    */
-  async voteOnDecision(prompt: string, options: string[]): Promise<string> {
-    if (this.panel.length === 0 || options.length === 0) {
+  async voteOnDecision(
+    prompt: string,
+    options: string[],
+    providerNames?: string[],
+    requestId?: string
+  ): Promise<string> {
+    const configs = this.getConfigsByProviders(providerNames);
+
+    if (configs.length === 0 || options.length === 0) {
       return options[0] || 'No options provided';
     }
 
@@ -113,12 +192,16 @@ Please vote on ONE of these options: ${options.join(', ')}
 Respond with ONLY the option you choose, exactly as written.`;
 
     // Create voting promises with concurrency limit
-    const votePromises = this.panel.map(async (_, i) => {
+    const votePromises = configs.map(async ({ index, config }) => {
       try {
-        const response = await this.queryLLM(i, votePrompt);
-        return { response, success: true, index: i };
+        const response = await this.queryLLM(
+          index,
+          votePrompt,
+          requestId ? `${requestId}:${config.provider}` : undefined
+        );
+        return { response, success: true, index };
       } catch {
-        return { response: options[0], success: false, index: i };
+        return { response: options[0], success: false, index };
       }
     });
 
@@ -162,8 +245,13 @@ Respond with ONLY the option you choose, exactly as written.`;
   /**
    * Conference system for collaborative discussion
    */
-  async conference(prompt: string): Promise<string> {
-    if (this.panel.length === 0) {
+  async conference(
+    prompt: string,
+    providerNames?: string[],
+    requestId?: string
+  ): Promise<string> {
+    const configs = this.getConfigsByProviders(providerNames);
+    if (configs.length === 0) {
       return 'No LLMs configured for conference';
     }
 
@@ -171,10 +259,13 @@ Respond with ONLY the option you choose, exactly as written.`;
     const discussionHistory: string[] = [prompt];
 
     // Sequential discussion with each LLM
-    for (let i = 0; i < this.panel.length; i++) {
-      const config = this.panel[i];
-      const response = await this.queryLLM(i, discussion);
-      const contribution = `\nLLM ${i + 1} (${config.role} - ${config.provider}): ${response}`;
+    for (const { config, index } of configs) {
+      const response = await this.queryLLM(
+        index,
+        discussion,
+        requestId ? `${requestId}:${config.provider}` : undefined
+      );
+      const contribution = `\nLLM ${index + 1} (${config.role} - ${config.provider}): ${response}`;
       discussion += contribution;
       discussionHistory.push(contribution);
     }
@@ -230,6 +321,163 @@ Respond with ONLY the option you choose, exactly as written.`;
     }
 
     return models;
+  }
+
+  getPanelConfigurations(): LLMConfig[] {
+    return [...this.panel];
+  }
+
+  getRequestMetrics(providerName?: string): LLMRequestMetric[] {
+    if (!providerName) {
+      return [...this.requestMetrics];
+    }
+
+    const normalized = providerName.toLowerCase();
+    return this.requestMetrics.filter(metric => metric.provider.toLowerCase() === normalized);
+  }
+
+  getProviderMetricsSummary(): ProviderMetricsSummary[] {
+    const summaryMap = new Map<
+      string,
+      {
+        provider: ProviderMetricsSummary['provider'];
+        model: string;
+        totalRequests: number;
+        successfulRequests: number;
+        latencySum: number;
+        costSum: number;
+        promptTokens: number;
+        completionTokens: number;
+        totalTokens: number;
+        lastUpdated: number;
+      }
+    >();
+
+    for (const metric of this.requestMetrics) {
+      const key = `${metric.provider}:${metric.model}`;
+      if (!summaryMap.has(key)) {
+        summaryMap.set(key, {
+          provider: metric.provider,
+          model: metric.model,
+          totalRequests: 0,
+          successfulRequests: 0,
+          latencySum: 0,
+          costSum: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          lastUpdated: metric.timestamp
+        });
+      }
+
+      const entry = summaryMap.get(key)!;
+      entry.totalRequests += 1;
+      entry.lastUpdated = Math.max(entry.lastUpdated, metric.timestamp);
+
+      if (metric.success) {
+        entry.successfulRequests += 1;
+        entry.latencySum += metric.latencyMs;
+        entry.costSum += metric.costUsd;
+        entry.promptTokens += metric.promptTokens;
+        entry.completionTokens += metric.completionTokens;
+        entry.totalTokens += metric.totalTokens;
+      }
+    }
+
+    return Array.from(summaryMap.values()).map(entry => ({
+      provider: entry.provider,
+      model: entry.model,
+      totalRequests: entry.totalRequests,
+      successfulRequests: entry.successfulRequests,
+      successRate: entry.totalRequests > 0 ? entry.successfulRequests / entry.totalRequests : 0,
+      avgLatencyMs: entry.successfulRequests > 0 ? entry.latencySum / entry.successfulRequests : 0,
+      avgCostUsd: entry.successfulRequests > 0 ? entry.costSum / entry.successfulRequests : 0,
+      promptTokens: entry.promptTokens,
+      completionTokens: entry.completionTokens,
+      totalTokens: entry.totalTokens,
+      lastUpdated: entry.lastUpdated
+    }));
+  }
+
+  getMetricsSnapshot(): { requests: LLMRequestMetric[]; providers: ProviderMetricsSummary[] } {
+    return {
+      requests: this.getRequestMetrics(),
+      providers: this.getProviderMetricsSummary()
+    };
+  }
+
+  estimateCost(
+    provider: LLMConfig['provider'],
+    promptTokens: number,
+    completionTokens: number
+  ): number {
+    return this.calculateCost(provider, promptTokens, completionTokens);
+  }
+
+  estimateCostFromTotalTokens(
+    provider: LLMConfig['provider'],
+    totalTokens: number,
+    completionRatio: number = 0.5
+  ): number {
+    if (totalTokens <= 0) {
+      return 0;
+    }
+
+    const completionTokens = Math.round(totalTokens * completionRatio);
+    const promptTokens = Math.max(totalTokens - completionTokens, 0);
+    return this.calculateCost(provider, promptTokens, completionTokens);
+  }
+
+  async queryByProvider(
+    providerName: string,
+    prompt: string,
+    model?: string,
+    requestId?: string
+  ): Promise<string> {
+    const index = this.findConfigIndex(providerName, model);
+    if (index === -1) {
+      if (this.panel.length > 0) {
+        const fallbackRequestId = requestId ? `${requestId}:fallback` : undefined;
+        return this.queryLLM(0, prompt, fallbackRequestId);
+      }
+      throw new Error(`No LLM configuration found for provider: ${providerName}`);
+    }
+
+    return this.queryLLM(index, prompt, requestId);
+  }
+
+  private findConfigIndex(providerName: string, model?: string): number {
+    const normalized = providerName.toLowerCase();
+
+    if (model) {
+      const exactMatch = this.panel.findIndex(
+        config =>
+          config.provider.toLowerCase() === normalized && config.model.toLowerCase() === model.toLowerCase()
+      );
+      if (exactMatch !== -1) {
+        return exactMatch;
+      }
+    }
+
+    return this.panel.findIndex(config => config.provider.toLowerCase() === normalized);
+  }
+
+  private getConfigsByProviders(providerNames?: string[]): { config: LLMConfig; index: number }[] {
+    const entries = this.panel.map((config, index) => ({ config, index }));
+
+    if (!providerNames || providerNames.length === 0) {
+      return entries;
+    }
+
+    const normalizedOrder = providerNames.map(name => name.toLowerCase());
+
+    return entries
+      .filter(entry => normalizedOrder.includes(entry.config.provider.toLowerCase()))
+      .sort(
+        (a, b) =>
+          normalizedOrder.indexOf(a.config.provider.toLowerCase()) -
+          normalizedOrder.indexOf(b.config.provider.toLowerCase())
+      );
   }
 
   /**
@@ -311,20 +559,11 @@ Respond with ONLY the option you choose, exactly as written.`;
    * Generate response from a specific provider
    * Compatibility method to support existing API usage
    */
-  async generateResponse(providerName: string, prompt: string): Promise<string> {
-    // Find the first config that matches the provider
-    const configIndex = this.panel.findIndex(config => 
-      config.provider.toLowerCase() === providerName.toLowerCase()
-    );
-    
-    if (configIndex === -1) {
-      // Fallback to the first available LLM if provider not found
-      if (this.panel.length > 0) {
-        return this.queryLLM(0, prompt);
-      }
-      throw new Error(`No LLM configuration found for provider: ${providerName}`);
-    }
-    
-    return this.queryLLM(configIndex, prompt);
+  async generateResponse(
+    providerName: string,
+    prompt: string,
+    options?: { requestId?: string; model?: string }
+  ): Promise<string> {
+    return this.queryByProvider(providerName, prompt, options?.model, options?.requestId);
   }
 }

--- a/src/workflow/workflowManager.ts
+++ b/src/workflow/workflowManager.ts
@@ -11,6 +11,7 @@
 
 import * as vscode from 'vscode';
 import { LLMManager } from '../llm/llmManager';
+import { AgentEconomy, RoutingAllocation, RoutingPlan } from '../llm/agentEconomy';
 import { VectorDB } from '../db/vectorDB';
 import { GitManager } from '../git/gitManager';
 import { AdaptiveWorkflowRL } from '../rl/adaptiveWorkflow';
@@ -70,6 +71,12 @@ export class WorkflowManager {
   /** Unique identifier for this workspace session */
   private workspaceId: string;
 
+  /** Agent economy responsible for routing decisions */
+  private agentEconomy: AgentEconomy;
+
+  /** Current routing plan provided by the agent economy */
+  private workflowRoutingPlan?: RoutingPlan;
+
   /**
    * Initialize the WorkflowManager with required dependencies
    *
@@ -91,6 +98,8 @@ export class WorkflowManager {
       userFeedback: [],
       iterations: 0,
     };
+
+    this.agentEconomy = new AgentEconomy(this.llmManager);
 
     this.initializeCollaboration();
   }
@@ -131,6 +140,67 @@ export class WorkflowManager {
     }
   }
 
+  private refreshRoutingPlan(
+    context: string,
+    priority: 'low' | 'medium' | 'high' | 'critical',
+    costBudget?: number
+  ): RoutingPlan {
+    const plan = this.agentEconomy.createRoutingPlan({
+      requestId: `${this.workspaceId}-${context}-${Date.now()}`,
+      prompt: this.projectIdea || context,
+      priority,
+      costBudget,
+      contextType: 'workflow',
+      metadata: { context }
+    });
+    this.workflowRoutingPlan = plan;
+    return plan;
+  }
+
+  private ensureRoutingPlan(
+    context: string = 'default',
+    priority: 'low' | 'medium' | 'high' | 'critical' = 'medium'
+  ): RoutingPlan {
+    if (!this.workflowRoutingPlan || this.workflowRoutingPlan.allocations.length === 0) {
+      return this.refreshRoutingPlan(context, priority);
+    }
+    return this.workflowRoutingPlan;
+  }
+
+  private getActiveProviderNames(): string[] {
+    const plan = this.ensureRoutingPlan();
+    if (!plan.allocations.length) {
+      return this.llmManager.getPanelConfigurations().map(config => config.provider);
+    }
+    return plan.allocations.map(allocation => allocation.provider);
+  }
+
+  private getPrimaryAllocation(): RoutingAllocation {
+    const plan = this.ensureRoutingPlan();
+    if (!plan.allocations.length) {
+      throw new Error('Agent economy returned no routing allocations');
+    }
+    return plan.allocations[0];
+  }
+
+  private createWorkflowRequestId(label: string): string {
+    return `${this.workspaceId}:${label}:${Date.now()}`;
+  }
+
+  private mapPhasePriority(phase: string): 'low' | 'medium' | 'high' | 'critical' {
+    switch (phase) {
+      case 'Deployment':
+        return 'high';
+      case 'Testing':
+        return 'high';
+      case 'Prototyping':
+        return 'medium';
+      case 'Planning':
+      default:
+        return 'medium';
+    }
+  }
+
   /**
    * Start a new development workflow from a project idea
    *
@@ -150,32 +220,48 @@ export class WorkflowManager {
     this.currentPhase = 0;
 
     try {
+      this.refreshRoutingPlan('initial-planning', option === 'letPanelDecide' ? 'high' : 'medium');
+      const providerNames = this.getActiveProviderNames();
+
       let prompt = idea;
       if (option === 'letPanelDecide') {
-        prompt = await this.llmManager.conference(`Refine this project idea: ${idea}`);
+        prompt = await this.llmManager.conference(
+          `Refine this project idea: ${idea}`,
+          providerNames,
+          this.createWorkflowRequestId('refine-idea')
+        );
       }
 
       // Step 2: Conferencing
       const discussion = await this.llmManager.conference(
-        `Discuss project: ${prompt}. Propose tech stack, estimates, plan.`
+        `Discuss project: ${prompt}. Propose tech stack, estimates, plan.`,
+        providerNames,
+        this.createWorkflowRequestId('initial-conference')
       );
 
-      this.buildPlan = await this.llmManager.voteOnDecision(discussion, [
-        'Approve Plan',
-        'Need Questions',
-      ]);
+      this.buildPlan = await this.llmManager.voteOnDecision(
+        discussion,
+        ['Approve Plan', 'Need Questions'],
+        providerNames,
+        this.createWorkflowRequestId('plan-vote')
+      );
 
       if (this.buildPlan === 'Need Questions') {
-        const questions = await this.llmManager.queryLLM(
-          0,
-          `Generate 5-10 questions for clarification on ${prompt}`
+        const primaryAllocation = this.getPrimaryAllocation();
+        const questions = await this.llmManager.queryByProvider(
+          primaryAllocation.provider,
+          `Generate 5-10 questions for clarification on ${prompt}`,
+          primaryAllocation.model,
+          this.createWorkflowRequestId('clarification-questions')
         );
         const answers = await vscode.window.showInputBox({
           prompt: `Please answer these questions: ${questions}`,
         });
         if (answers) {
           this.buildPlan = await this.llmManager.conference(
-            `Incorporate answers: ${answers}. Finalize plan.`
+            `Incorporate answers: ${answers}. Finalize plan.`,
+            providerNames,
+            this.createWorkflowRequestId('incorporate-answers')
           );
         }
       }
@@ -197,6 +283,9 @@ export class WorkflowManager {
     this.metrics.phaseStartTime = Date.now();
 
     try {
+      this.refreshRoutingPlan(`phase-${phase.toLowerCase()}`, this.mapPhasePriority(phase));
+      const providerNames = this.getActiveProviderNames();
+
       // Get current workflow state for RL
       const currentState = this.getCurrentWorkflowState();
 
@@ -232,7 +321,11 @@ export class WorkflowManager {
 
       // Generate phase content with enhanced prompting
       const phasePrompt = this.buildEnhancedPrompt(phase, contextText);
-      const output = await this.llmManager.conference(phasePrompt);
+      const output = await this.llmManager.conference(
+        phasePrompt,
+        providerNames,
+        this.createWorkflowRequestId(`phase-${phase}-execution`)
+      );
 
       // Process and validate output
       const processedOutput = await this.processPhaseOutput(output, phase);
@@ -429,7 +522,11 @@ export class WorkflowManager {
 
   private async conductPhaseReview(output: string, phase: string): Promise<string> {
     const reviewPrompt = `Review this ${phase} phase output for quality, completeness, and potential issues:\n\n${output}`;
-    return await this.llmManager.conference(reviewPrompt);
+    return await this.llmManager.conference(
+      reviewPrompt,
+      this.getActiveProviderNames(),
+      this.createWorkflowRequestId(`review-${phase}`)
+    );
   }
 
   private async generateIntelligentSuggestions(
@@ -438,7 +535,13 @@ export class WorkflowManager {
     contextText: string
   ): Promise<string> {
     const suggestionPrompt = `Based on the ${phase} output and context, suggest 3-5 specific improvements or innovations:\n\nOutput:\n${output}\n\nContext:\n${contextText}`;
-    return await this.llmManager.queryLLM(0, suggestionPrompt);
+    const primary = this.getPrimaryAllocation();
+    return await this.llmManager.queryByProvider(
+      primary.provider,
+      suggestionPrompt,
+      primary.model,
+      this.createWorkflowRequestId(`suggestions-${phase}`)
+    );
   }
 
   private async getUserDecision(suggestions: string, review: string): Promise<string> {
@@ -473,7 +576,9 @@ export class WorkflowManager {
       case 'Apply suggestions': {
         feedback = 0.9;
         const improvedOutput = await this.llmManager.conference(
-          `Apply these suggestions: ${suggestions} to improve: ${output}`
+          `Apply these suggestions: ${suggestions} to improve: ${output}`,
+          this.getActiveProviderNames(),
+          this.createWorkflowRequestId(`apply-suggestions-${phase}`)
         );
         await this.writePhaseOutput(improvedOutput, `${phase}_improved`);
         break;
@@ -486,7 +591,9 @@ export class WorkflowManager {
         });
         if (modification) {
           const modifiedOutput = await this.llmManager.conference(
-            `Apply these modifications: ${modification} to: ${output}`
+            `Apply these modifications: ${modification} to: ${output}`,
+            this.getActiveProviderNames(),
+            this.createWorkflowRequestId(`apply-modifications-${phase}`)
           );
           await this.writePhaseOutput(modifiedOutput, `${phase}_modified`);
         }
@@ -495,9 +602,12 @@ export class WorkflowManager {
 
       case 'Get more details': {
         feedback = 0.6;
-        const details = await this.llmManager.queryLLM(
-          0,
-          `Provide more detailed explanation for: ${output}`
+        const primary = this.getPrimaryAllocation();
+        const details = await this.llmManager.queryByProvider(
+          primary.provider,
+          `Provide more detailed explanation for: ${output}`,
+          primary.model,
+          this.createWorkflowRequestId(`details-${phase}`)
         );
         vscode.window.showInformationMessage(`Details: ${details.substring(0, 200)}...`);
         break;
@@ -555,18 +665,25 @@ export class WorkflowManager {
 
   private async completeProject() {
     try {
+      this.refreshRoutingPlan('project-completion', 'high');
+      const primary = this.getPrimaryAllocation();
+
       // Generate comprehensive final report with metrics
       const totalTime = Date.now() - this.metrics.startTime;
       const rlStats = this.workflowRL.getStats();
 
-      const report = await this.llmManager.queryLLM(
-        0,
-        `Generate a comprehensive final report for ${this.projectIdea}. Include project summary, key achievements, and lessons learned.`
+      const report = await this.llmManager.queryByProvider(
+        primary.provider,
+        `Generate a comprehensive final report for ${this.projectIdea}. Include project summary, key achievements, and lessons learned.`,
+        primary.model,
+        this.createWorkflowRequestId('final-report')
       );
 
-      const bonuses = await this.llmManager.queryLLM(
-        0,
-        `Suggest 5 innovative A+ enhancements for ${this.projectIdea}, considering cutting-edge technologies like AI, blockchain, and real-time collaboration.`
+      const bonuses = await this.llmManager.queryByProvider(
+        primary.provider,
+        `Suggest 5 innovative A+ enhancements for ${this.projectIdea}, considering cutting-edge technologies like AI, blockchain, and real-time collaboration.`,
+        primary.model,
+        this.createWorkflowRequestId('final-enhancements')
       );
 
       const finalReport = `# AstraForge Project Completion Report


### PR DESCRIPTION
## Summary
- add per-request metrics tracking to the LLM manager with provider pricing utilities and routing helpers
- implement an agent economy module that scores providers, respects budgets, and issues routing allocations
- update workflow and collaboration managers to consume routing plans, scope LLM usage by allocation, and propagate request ids for telemetry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ce3dc0de3c832c8d60d89f4ffa55a6